### PR TITLE
Add GHA release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,38 @@
+name: Docker Hub
+
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+      - '!v[0-9]+.[0-9]+.[0-9]+[ab][0-9]+'
+
+env:
+  REPO: csdms/cem-grpc4bmi
+
+jobs:
+
+  build-and-push:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Get version
+        id: vars
+        run: echo "version=${GITHUB_REF:11}" >> $GITHUB_OUTPUT
+
+      - name: Set up Docker buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          platforms: linux/amd64,linux/arm64
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ env.REPO }}:latest,${{ env.REPO }}:${{ steps.vars.outputs.version }}

--- a/README.md
+++ b/README.md
@@ -42,6 +42,23 @@ If the image isn't found locally, it's pulled from Docker Hub
 For more in-depth examples of running the CEM model through grpc4bmi,
 see the [examples](./examples) directory.
 
+## Developer notes
+
+A versioned, multiplatform image is hosted on Docker Hub
+at [csdms/cem-grpc4bmi](https://hub.docker.com/r/csdms/cem-grpc4bmi).
+This image is automatically built and pushed to Docker Hub
+with the [release](./.github/workflows/release.yml) CI workflow.
+The workflow is only run when the repository is tagged.
+To manually build and push an update, run:
+```
+docker buildx build --platform linux/amd64,linux/arm64 -t csdms/cem-grpc4bmi:latest --push .
+```
+A user can pull this image from Docker Hub with:
+```
+docker pull csdms/cem-grpc4bmi
+```
+optionally with the `latest` tag or with a version tag.
+
 ## Acknowledgment
 
 This work is supported by the U.S. National Science Foundation under Award No. [2103878](https://www.nsf.gov/awardsearch/showAward?AWD_ID=2103878), *Frameworks: Collaborative Research: Integrative Cyberinfrastructure for Next-Generation Modeling Science*.


### PR DESCRIPTION
This PR adds a GitHub Actions workflow that builds a multiplatform image and uploads it to Docker Hub when the repository is tagged.